### PR TITLE
Ability to configure Caddy

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,10 @@ config :uplink, Uplink.Internal, port: 4080
 
 config :uplink, Uplink.Router, port: 4040
 
+config :uplink, Uplink.Clients.Caddy,
+  endpoint: System.get_env("CADDY_ADMIN_ENDPOINT", "http://localhost:2019"),
+  zero_ssl_api_key: System.get_env("ZERO_SSL_API_KEY", "")
+
 config :uplink, Oban,
   repo: Uplink.Repo,
   queues: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,7 @@ config :uplink, Uplink.Secret, "secretsomethingsixteen"
 config :uplink, Uplink.Clients.Instellar, endpoint: "http://localhost/uplink"
 
 config :uplink, Uplink.Repo,
-  database: System.get_env("UPLINK_DB_NAME"),
+  database: System.get_env("UPLINK_DB_NAME", "uplink_dev"),
   username: System.get_env("UPLINK_DB_USERNAME"),
   password: System.get_env("UPLINK_DB_PASSWORD"),
   hostname: System.get_env("UPLINK_DB_HOST") || "localhost",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,6 +4,8 @@ config :uplink, Uplink.Secret, "secretsomethingsixteen"
 
 config :uplink, Uplink.Clients.Instellar, endpoint: "http://localhost/uplink"
 
+config :uplink, :environment, :dev
+
 config :uplink, Uplink.Repo,
   database: System.get_env("UPLINK_DB_NAME", "uplink_dev"),
   username: System.get_env("UPLINK_DB_USERNAME"),

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -7,7 +7,7 @@ config :uplink, Uplink.Clients.Instellar,
     System.get_env("INSTELLAR_ENDPOINT", "https://web.instellar.app/uplink")
 
 config :uplink, Uplink.Clients.Caddy,
-  zero_ssl_api_key: System.get("ZERO_SSL_API_KEY", "")
+  zero_ssl_api_key: System.get_env("ZERO_SSL_API_KEY", "")
 
 config :uplink, Uplink.Cluster,
   installation_id: System.get_env("UPLINK_INSTALLATION_ID")

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -7,6 +7,7 @@ config :uplink, Uplink.Clients.Instellar,
     System.get_env("INSTELLAR_ENDPOINT", "https://web.instellar.app/uplink")
 
 config :uplink, Uplink.Clients.Caddy,
+  endpoint: System.get_env("CADDY_ADMIN_ENDPOINT", "http://localhost:2019"),
   zero_ssl_api_key: System.get_env("ZERO_SSL_API_KEY", "")
 
 config :uplink, Uplink.Cluster,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -6,6 +6,9 @@ config :uplink, Uplink.Clients.Instellar,
   endpoint:
     System.get_env("INSTELLAR_ENDPOINT", "https://web.instellar.app/uplink")
 
+config :uplink, Uplink.Clients.Caddy,
+  zero_ssl_api_key: System.get("ZERO_SSL_API_KEY", "")
+
 config :uplink, Uplink.Cluster,
   installation_id: System.get_env("UPLINK_INSTALLATION_ID")
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,6 +13,9 @@ config :uplink, Uplink.Repo,
   queue_interval: 50_000,
   pool: Ecto.Adapters.SQL.Sandbox
 
+config :uplink, Uplink.Clients.Caddy,
+  zero_ssl_api_key: System.get_env("ZERO_SSL_API_KEY", "")
+
 config :uplink, :environment, :test
 config :lexdee, :environment, :test
 

--- a/instellar.yml
+++ b/instellar.yml
@@ -2,6 +2,7 @@ dependencies:
   build:
     - elixir
   runtime:
+    - caddy
     - bash
     - curl
     - jq
@@ -35,6 +36,7 @@ run:
 
 hook:
   post-install: |
+    rc-update add caddy
     rc-update add uplink
 
   pre-upgrade: |

--- a/lib/uplink/application.ex
+++ b/lib/uplink/application.ex
@@ -38,7 +38,7 @@ defmodule Uplink.Application do
     Supervisor.start_link(children, opts)
   end
 
-  defp append_live_only_services(children, :test),
+  defp append_live_only_services(children, env) when env in [:test, :dev],
     do: children
 
   defp append_live_only_services(children, _),

--- a/lib/uplink/clients/caddy.ex
+++ b/lib/uplink/clients/caddy.ex
@@ -1,0 +1,16 @@
+defmodule Uplink.Clients.Caddy do
+  @endpoint "http://localhost:2019"
+
+  def default_endpoint, do: @endpoint
+  
+  defdelegate get_config, 
+    to: __MODULE__.Config, as: :get
+  
+  defdelegate load_config(params), 
+    to: __MODULE__.Config, as: :load
+
+  def config(key) do
+    Application.get_env(:uplink, __MODULE__)
+    |> Keyword.get(key)
+  end
+end

--- a/lib/uplink/clients/caddy.ex
+++ b/lib/uplink/clients/caddy.ex
@@ -1,9 +1,24 @@
 defmodule Uplink.Clients.Caddy do
   @endpoint "http://localhost:2019"
 
+  alias __MODULE__.{
+    Config
+  }
+
   def default_endpoint, do: @endpoint
 
-  defdelegate get_config, to: __MODULE__.Config, as: :get
+  def get_config do
+    case Config.get() do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, body} ->
+        {:ok, Config.parse(body)}
+
+      error ->
+        error
+    end
+  end
 
   defdelegate load_config(params), to: __MODULE__.Config, as: :load
 

--- a/lib/uplink/clients/caddy.ex
+++ b/lib/uplink/clients/caddy.ex
@@ -2,12 +2,10 @@ defmodule Uplink.Clients.Caddy do
   @endpoint "http://localhost:2019"
 
   def default_endpoint, do: @endpoint
-  
-  defdelegate get_config, 
-    to: __MODULE__.Config, as: :get
-  
-  defdelegate load_config(params), 
-    to: __MODULE__.Config, as: :load
+
+  defdelegate get_config, to: __MODULE__.Config, as: :get
+
+  defdelegate load_config(params), to: __MODULE__.Config, as: :load
 
   def config(key) do
     Application.get_env(:uplink, __MODULE__)

--- a/lib/uplink/clients/caddy.ex
+++ b/lib/uplink/clients/caddy.ex
@@ -1,11 +1,7 @@
 defmodule Uplink.Clients.Caddy do
-  @endpoint "http://localhost:2019"
-
   alias __MODULE__.{
     Config
   }
-
-  def default_endpoint, do: @endpoint
 
   def get_config do
     case Config.get() do

--- a/lib/uplink/clients/caddy/admin.ex
+++ b/lib/uplink/clients/caddy/admin.ex
@@ -6,7 +6,7 @@ defmodule Uplink.Clients.Caddy.Admin do
 
   @primary_key false
   embedded_schema do
-    embeds_one :identity, primary_key: false do
+    embeds_one :identity, Identity, primary_key: false do
       field :identifiers, {:array, :string}
 
       embeds_many :issuers, Issuer

--- a/lib/uplink/clients/caddy/admin.ex
+++ b/lib/uplink/clients/caddy/admin.ex
@@ -1,24 +1,24 @@
 defmodule Uplink.Clients.Caddy.Admin do
-	use Ecto.Schema
+  use Ecto.Schema
   import Ecto.Changeset
-  
+
   alias __MODULE__.Issuer
 
   @primary_key false
   embedded_schema do
     embeds_one :identity, primary_key: false do
       field :identifiers, {:array, :string}
-      
+
       embeds_many :issuers, Issuer
     end
   end
-  
+
   def changeset(admin, params) do
     admin
     |> cast(params, [])
     |> cast_embed(:identity)
   end
-  
+
   def parse(params) do
     %__MODULE__{}
     |> changeset(params)

--- a/lib/uplink/clients/caddy/admin.ex
+++ b/lib/uplink/clients/caddy/admin.ex
@@ -1,0 +1,27 @@
+defmodule Uplink.Clients.Caddy.Admin do
+	use Ecto.Schema
+  import Ecto.Changeset
+  
+  alias __MODULE__.Issuer
+
+  @primary_key false
+  embedded_schema do
+    embeds_one :identity, primary_key: false do
+      field :identifiers, {:array, :string}
+      
+      embeds_many :issuers, Issuer
+    end
+  end
+  
+  def changeset(admin, params) do
+    admin
+    |> cast(params, [])
+    |> cast_embed(:identity)
+  end
+  
+  def parse(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:insert)
+  end
+end

--- a/lib/uplink/clients/caddy/admin.ex
+++ b/lib/uplink/clients/caddy/admin.ex
@@ -16,12 +16,18 @@ defmodule Uplink.Clients.Caddy.Admin do
   def changeset(admin, params) do
     admin
     |> cast(params, [])
-    |> cast_embed(:identity)
+    |> cast_embed(:identity, with: &identity_changeset/2)
   end
 
   def parse(params) do
     %__MODULE__{}
     |> changeset(params)
     |> apply_action!(:insert)
+  end
+  
+  defp identity_changeset(identity, params) do
+    identity
+    |> cast(params, [:identifiers])
+    |> cast_embed(:issuers)
   end
 end

--- a/lib/uplink/clients/caddy/admin.ex
+++ b/lib/uplink/clients/caddy/admin.ex
@@ -24,7 +24,7 @@ defmodule Uplink.Clients.Caddy.Admin do
     |> changeset(params)
     |> apply_action!(:insert)
   end
-  
+
   defp identity_changeset(identity, params) do
     identity
     |> cast(params, [:identifiers])

--- a/lib/uplink/clients/caddy/admin/issuer.ex
+++ b/lib/uplink/clients/caddy/admin/issuer.ex
@@ -1,17 +1,17 @@
 defmodule Uplink.Clients.Caddy.Admin.Issuer do
-	use Ecto.Schema
+  use Ecto.Schema
   import Ecto.Changeset
-  
+
   @valid_attrs ~w(
     module
   )a
-  
+
   @primary_key false
   embedded_schema do
     field :module, :string
     field :api_key, :string
   end
-  
+
   def changeset(issuer, params) do
     issuer
     |> cast(params, @valid_attrs)

--- a/lib/uplink/clients/caddy/admin/issuer.ex
+++ b/lib/uplink/clients/caddy/admin/issuer.ex
@@ -1,0 +1,20 @@
+defmodule Uplink.Clients.Caddy.Admin.Issuer do
+	use Ecto.Schema
+  import Ecto.Changeset
+  
+  @valid_attrs ~w(
+    module
+  )a
+  
+  @primary_key false
+  embedded_schema do
+    field :module, :string
+    field :api_key, :string
+  end
+  
+  def changeset(issuer, params) do
+    issuer
+    |> cast(params, @valid_attrs)
+    |> validate_inclusion(:module, ["zerossl", "acme", "internal"])
+  end
+end

--- a/lib/uplink/clients/caddy/admin/issuer/zero_ssl.ex
+++ b/lib/uplink/clients/caddy/admin/issuer/zero_ssl.ex
@@ -1,20 +1,19 @@
-defmodule Uplink.Clients.Caddy.Admin.Issuer do
+defmodule Uplink.Clients.Caddy.Admin.ZeroSSL do
   use Ecto.Schema
   import Ecto.Changeset
 
   @valid_attrs ~w(
-    module
+    api_key
   )a
 
   @primary_key false
   embedded_schema do
-    field :module, :string
+    field :module, :string, default: "zerossl"
     field :api_key, :string
   end
 
   def changeset(issuer, params) do
     issuer
     |> cast(params, @valid_attrs)
-    |> validate_inclusion(:module, ["zerossl", "acme", "internal"])
   end
 end

--- a/lib/uplink/clients/caddy/admin/issuer/zero_ssl.ex
+++ b/lib/uplink/clients/caddy/admin/issuer/zero_ssl.ex
@@ -1,4 +1,4 @@
-defmodule Uplink.Clients.Caddy.Admin.ZeroSSL do
+defmodule Uplink.Clients.Caddy.Admin.Issuer.ZeroSSL do
   use Ecto.Schema
   import Ecto.Changeset
 
@@ -15,5 +15,11 @@ defmodule Uplink.Clients.Caddy.Admin.ZeroSSL do
   def changeset(issuer, params) do
     issuer
     |> cast(params, @valid_attrs)
+  end
+
+  def parse(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:insert)
   end
 end

--- a/lib/uplink/clients/caddy/apps.ex
+++ b/lib/uplink/clients/caddy/apps.ex
@@ -1,6 +1,8 @@
 defmodule Uplink.Clients.Caddy.Apps do
   use Ecto.Schema
   import Ecto.Changeset
+  
+  alias __MODULE__.Server
 
   @primary_key false
   embedded_schema do
@@ -8,4 +10,25 @@ defmodule Uplink.Clients.Caddy.Apps do
       field :servers, :map
     end
   end
+  
+  def changeset(apps, params) do
+    apps
+    |> cast(params, [:servers])
+    |> maybe_cast_servers()
+  end
+  
+  def maybe_cast_servers(changeset) do
+    if servers = get_change(changeset, :servers) do
+      servers =
+        servers
+        |> Enum.map(fn {key, value} -> 
+          {key, Server.parse(value)}
+        end)
+        |> Enum.into(%{})
+      
+      put_change(changeset, :servers, servers)
+    else
+      changeset
+    end
+  end 
 end

--- a/lib/uplink/clients/caddy/apps.ex
+++ b/lib/uplink/clients/caddy/apps.ex
@@ -1,0 +1,11 @@
+defmodule Uplink.Clients.Caddy.Apps do
+	use Ecto.Schema
+  import Ecto.Changeset
+  
+  @primary_key false
+  embedded_schema do
+    embeds_one :http, Http, primary_key: false do
+      field :servers, :map
+    end
+  end
+end

--- a/lib/uplink/clients/caddy/apps.ex
+++ b/lib/uplink/clients/caddy/apps.ex
@@ -1,7 +1,7 @@
 defmodule Uplink.Clients.Caddy.Apps do
   use Ecto.Schema
   import Ecto.Changeset
-  
+
   alias __MODULE__.Server
 
   @primary_key false
@@ -10,25 +10,31 @@ defmodule Uplink.Clients.Caddy.Apps do
       field :servers, :map
     end
   end
-  
+
   def changeset(apps, params) do
     apps
     |> cast(params, [:servers])
     |> maybe_cast_servers()
   end
-  
-  def maybe_cast_servers(changeset) do
+
+  def parse(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:insert)
+  end
+
+  defp maybe_cast_servers(changeset) do
     if servers = get_change(changeset, :servers) do
       servers =
         servers
-        |> Enum.map(fn {key, value} -> 
+        |> Enum.map(fn {key, value} ->
           {key, Server.parse(value)}
         end)
         |> Enum.into(%{})
-      
+
       put_change(changeset, :servers, servers)
     else
       changeset
     end
-  end 
+  end
 end

--- a/lib/uplink/clients/caddy/apps.ex
+++ b/lib/uplink/clients/caddy/apps.ex
@@ -1,7 +1,7 @@
 defmodule Uplink.Clients.Caddy.Apps do
-	use Ecto.Schema
+  use Ecto.Schema
   import Ecto.Changeset
-  
+
   @primary_key false
   embedded_schema do
     embeds_one :http, Http, primary_key: false do

--- a/lib/uplink/clients/caddy/apps.ex
+++ b/lib/uplink/clients/caddy/apps.ex
@@ -13,6 +13,12 @@ defmodule Uplink.Clients.Caddy.Apps do
 
   def changeset(apps, params) do
     apps
+    |> cast(params, [])
+    |> cast_embed(:http, with: &http_changeset/2)
+  end
+
+  defp http_changeset(http, params) do
+    http
     |> cast(params, [:servers])
     |> maybe_cast_servers()
   end

--- a/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
+++ b/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
@@ -1,18 +1,18 @@
 defmodule Uplink.Clients.Caddy.Apps.Handler.ReverseProxy do
-	use Ecto.Schema
+  use Ecto.Schema
   import Ecto.Changeset
-  
+
   @primary_key false
   embedded_schema do
     field :handler, :string
-    
+
     embeds_one :health_checks, HealthChecks, primary_key: false do
       embeds_one :active, Active, primary_key: false do
         field :path, :string
         field :uri, :string
         field :port, :integer, default: 0
         field :headers, :map
-        
+
         field :interval, :integer, default: 0
         field :timeout, :integer, default: 0
         field :max_size, :integer, default: 0
@@ -20,25 +20,25 @@ defmodule Uplink.Clients.Caddy.Apps.Handler.ReverseProxy do
         field :expect_body, :string, default: ""
       end
     end
-    
+
     embeds_many :upstreams, Upstream, primary_key: false do
       field :dial, :string, default: ""
       field :max_requests, :integer, default: 10
     end
   end
-  
+
   def changeset(reverse_proxy, params) do
     reverse_proxy
     |> cast(params, [:handler])
     |> cast_embed(:health_checks, with: &health_checks_changeset/2)
     |> cast_embed(:upstreams, with: &upstream_changeset/2)
   end
-  
+
   defp health_checks_changeset(health_checks, params) do
     health_checks
     |> cast_embed(:active, with: &active_changeset/2)
   end
-  
+
   defp upstream_changeset(upstream, params) do
     upstream
     |> cast(params, [:dial, :max_requests])

--- a/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
+++ b/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
@@ -36,11 +36,26 @@ defmodule Uplink.Clients.Caddy.Apps.Handler.ReverseProxy do
 
   defp health_checks_changeset(health_checks, params) do
     health_checks
-    |> cast_embed(:active, with: &active_changeset/2)
+    |> cast_embed(:active, with: &active_health_check_changeset/2)
   end
 
   defp upstream_changeset(upstream, params) do
     upstream
     |> cast(params, [:dial, :max_requests])
+  end
+
+  defp active_health_check_changeset(active_health_check, params) do
+    active_health_check
+    |> cast(params, [
+      :path,
+      :uri,
+      :port,
+      :headers,
+      :interval,
+      :timeout,
+      :max_size,
+      :expect_status,
+      :expect_body
+    ])
   end
 end

--- a/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
+++ b/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
@@ -1,0 +1,46 @@
+defmodule Uplink.Clients.Caddy.Apps.Handler.ReverseProxy do
+	use Ecto.Schema
+  import Ecto.Changeset
+  
+  @primary_key false
+  embedded_schema do
+    field :handler, :string
+    
+    embeds_one :health_checks, HealthChecks, primary_key: false do
+      embeds_one :active, Active, primary_key: false do
+        field :path, :string
+        field :uri, :string
+        field :port, :integer, default: 0
+        field :headers, :map
+        
+        field :interval, :integer, default: 0
+        field :timeout, :integer, default: 0
+        field :max_size, :integer, default: 0
+        field :expect_status, :integer, default: 0
+        field :expect_body, :string, default: ""
+      end
+    end
+    
+    embeds_many :upstreams, Upstream, primary_key: false do
+      field :dial, :string, default: ""
+      field :max_requests, :integer, default: 10
+    end
+  end
+  
+  def changeset(reverse_proxy, params) do
+    reverse_proxy
+    |> cast(params, [:handler])
+    |> cast_embed(:health_checks, with: &health_checks_changeset/2)
+    |> cast_embed(:upstreams, with: &upstream_changeset/2)
+  end
+  
+  defp health_checks_changeset(health_checks, params) do
+    health_checks
+    |> cast_embed(:active, with: &active_changeset/2)
+  end
+  
+  defp upstream_changeset(upstream, params) do
+    upstream
+    |> cast(params, [:dial, :max_requests])
+  end
+end

--- a/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
+++ b/lib/uplink/clients/caddy/apps/handler/reverse_proxy.ex
@@ -36,6 +36,7 @@ defmodule Uplink.Clients.Caddy.Apps.Handler.ReverseProxy do
 
   defp health_checks_changeset(health_checks, params) do
     health_checks
+    |> cast(params, [])
     |> cast_embed(:active, with: &active_health_check_changeset/2)
   end
 

--- a/lib/uplink/clients/caddy/apps/server.ex
+++ b/lib/uplink/clients/caddy/apps/server.ex
@@ -20,7 +20,7 @@ defmodule Uplink.Clients.Caddy.Apps.Server do
     |> cast(params, [:listen])
     |> cast_assoc(:routes, with: &route_changeset/2)
   end
-  
+
   def parse(params) do
     %__MODULE__{}
     |> changeset(params)

--- a/lib/uplink/clients/caddy/apps/server.ex
+++ b/lib/uplink/clients/caddy/apps/server.ex
@@ -7,18 +7,21 @@ defmodule Uplink.Clients.Caddy.Apps.Server do
     field :listen, {:array, :string}
 
     embeds_many :routes, Route, primary_key: false do
+      field :group, :string, default: ""
+
       embeds_many :match, Match, primary_key: false do
         field :host, {:array, :string}
       end
 
       field :handle, {:array, :map}
+      field :terminal, :boolean, default: false
     end
   end
 
   def changeset(server, params) do
     server
     |> cast(params, [:listen])
-    |> cast_assoc(:routes, with: &route_changeset/2)
+    |> cast_embed(:routes, with: &route_changeset/2)
   end
 
   def parse(params) do
@@ -30,7 +33,7 @@ defmodule Uplink.Clients.Caddy.Apps.Server do
   defp route_changeset(route, params) do
     route
     |> cast(params, [:handle])
-    |> cast_assoc(:match, with: &match_changeset/2)
+    |> cast_embed(:match, with: &match_changeset/2)
   end
 
   defp match_changeset(match, params) do

--- a/lib/uplink/clients/caddy/apps/server.ex
+++ b/lib/uplink/clients/caddy/apps/server.ex
@@ -20,6 +20,12 @@ defmodule Uplink.Clients.Caddy.Apps.Server do
     |> cast(params, [:listen])
     |> cast_assoc(:routes, with: &route_changeset/2)
   end
+  
+  def parse(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> apply_action!(:insert)
+  end
 
   defp route_changeset(route, params) do
     route

--- a/lib/uplink/clients/caddy/apps/server.ex
+++ b/lib/uplink/clients/caddy/apps/server.ex
@@ -1,0 +1,34 @@
+defmodule Uplink.Clients.Caddy.Apps.Server do
+	use Ecto.Schema
+  import Ecto.Changeset
+  
+  @primary_key false
+  embedded_schema do
+    field :listen, {:array, :string}
+    
+    embeds_many :routes, Route, primary_key: false do
+      embeds_many :match, Match, primary_key: false do
+        field :host, {:array, :string}
+      end
+      
+      field :handle, {:array, :map}
+    end
+  end
+  
+  def changeset(server, params) do
+    server
+    |> cast(params, [:listen])
+    |> cast_assoc(:routes, with: &route_changeset/2)
+  end
+  
+  defp route_changeset(route, params) do
+    route
+    |> cast(params, [:handle])
+    |> cast_assoc(:match, with: &match_changeset/2)
+  end
+  
+  defp match_changeset(match, params) do
+    match
+    |> cast(params, [:host])
+  end
+end

--- a/lib/uplink/clients/caddy/apps/server.ex
+++ b/lib/uplink/clients/caddy/apps/server.ex
@@ -1,32 +1,32 @@
 defmodule Uplink.Clients.Caddy.Apps.Server do
-	use Ecto.Schema
+  use Ecto.Schema
   import Ecto.Changeset
-  
+
   @primary_key false
   embedded_schema do
     field :listen, {:array, :string}
-    
+
     embeds_many :routes, Route, primary_key: false do
       embeds_many :match, Match, primary_key: false do
         field :host, {:array, :string}
       end
-      
+
       field :handle, {:array, :map}
     end
   end
-  
+
   def changeset(server, params) do
     server
     |> cast(params, [:listen])
     |> cast_assoc(:routes, with: &route_changeset/2)
   end
-  
+
   defp route_changeset(route, params) do
     route
     |> cast(params, [:handle])
     |> cast_assoc(:match, with: &match_changeset/2)
   end
-  
+
   defp match_changeset(match, params) do
     match
     |> cast(params, [:host])

--- a/lib/uplink/clients/caddy/config.ex
+++ b/lib/uplink/clients/caddy/config.ex
@@ -1,5 +1,7 @@
 defmodule Uplink.Clients.Caddy.Config do
-  alias Uplink.Clients.Caddy.{
+  alias Uplink.Clients.Caddy
+
+  alias Caddy.{
     Apps,
     Admin
   }
@@ -24,10 +26,10 @@ defmodule Uplink.Clients.Caddy.Config do
 
   def get do
     config_path =
-      [Uplink.Clients.Caddy.default_endpoint(), "config"]
+      [Caddy.config(:endpoint), "config"]
       |> Path.join()
 
-    config_path <> "/"
+    (config_path <> "/")
     |> Req.get!()
     |> case do
       %{status: 200, body: body} ->
@@ -39,7 +41,7 @@ defmodule Uplink.Clients.Caddy.Config do
   end
 
   def load(params) do
-    [Uplink.Clients.Caddy.default_endpoint(), "load"]
+    [Caddy.config(:endpoint), "load"]
     |> Path.join()
     |> Req.post!({:json, params})
     |> case do

--- a/lib/uplink/clients/caddy/config.ex
+++ b/lib/uplink/clients/caddy/config.ex
@@ -1,0 +1,27 @@
+defmodule Uplink.Clients.Caddy.Config do
+  def get do
+    [Uplink.Clients.Caddy.default_endpoint(), "config", "/"]
+    |> Path.join()
+    |> Req.get!()
+    |> case do
+      %{status: 200, body: body} ->
+        {:ok, body}
+
+      %{status: _, body: body} ->
+        {:error, body}
+    end
+  end
+  
+  def load(params) do
+    [Uplink.Clients.Caddy.default_endpoint(), "load"]
+    |> Path.join()
+    |> Req.post!({:json, params})
+    |> case do
+      %{status: 200, body: body} ->
+        {:ok, body}
+        
+      %{status: _, body: body} ->
+        {:error, body}
+    end
+  end
+end

--- a/lib/uplink/clients/caddy/config.ex
+++ b/lib/uplink/clients/caddy/config.ex
@@ -1,7 +1,33 @@
 defmodule Uplink.Clients.Caddy.Config do
+  alias Uplink.Clients.Caddy.{
+    Apps,
+    Admin
+  }
+
+  @mappings %{
+    "admin" => {:admin, Admin},
+    "apps" => {:apps, Apps}
+  }
+
+  def parse(body) do
+    body
+    |> Enum.map(fn {key, result} ->
+      if mapping = Map.get(@mappings, key) do
+        {atom_key, module} = mapping
+        {atom_key, module.parse(result)}
+      else
+        nil
+      end
+    end)
+    |> Enum.into(%{})
+  end
+
   def get do
-    [Uplink.Clients.Caddy.default_endpoint(), "config", "/"]
-    |> Path.join()
+    config_path =
+      [Uplink.Clients.Caddy.default_endpoint(), "config"]
+      |> Path.join()
+
+    config_path <> "/"
     |> Req.get!()
     |> case do
       %{status: 200, body: body} ->

--- a/lib/uplink/clients/caddy/config.ex
+++ b/lib/uplink/clients/caddy/config.ex
@@ -11,7 +11,7 @@ defmodule Uplink.Clients.Caddy.Config do
         {:error, body}
     end
   end
-  
+
   def load(params) do
     [Uplink.Clients.Caddy.default_endpoint(), "load"]
     |> Path.join()
@@ -19,7 +19,7 @@ defmodule Uplink.Clients.Caddy.Config do
     |> case do
       %{status: 200, body: body} ->
         {:ok, body}
-        
+
       %{status: _, body: body} ->
         {:error, body}
     end

--- a/lib/uplink/clients/caddy/config/builder.ex
+++ b/lib/uplink/clients/caddy/config/builder.ex
@@ -1,0 +1,34 @@
+defmodule Uplink.Clients.Caddy.Config.Builder do
+  alias Uplink.Clients.Caddy
+  alias Caddy.Admin
+  
+  def new do    
+    %{admin: admin(), apps: apps()}
+  end
+  
+	def admin do
+    zero_ssl_api_key = Caddy.config(:zero_ssl_api_key)
+    
+    %{
+      identity: %{
+        identifiers: [""],
+        issuers: [
+          %{module: "zerossl", api_key: zero_ssl_api_key}
+        ]
+      }
+    }
+    |> Admin.parse()
+  end
+  
+  def apps do
+    %{
+      http: %{
+        servers: servers()
+      }
+    }
+  end
+  
+  def servers do
+    
+  end
+end

--- a/lib/uplink/packages/app.ex
+++ b/lib/uplink/packages/app.ex
@@ -18,5 +18,6 @@ defmodule Uplink.Packages.App do
     app
     |> cast(params, [:slug])
     |> validate_required([:slug])
+    |> unique_constraint(:slug)
   end
 end

--- a/lib/uplink/packages/install.ex
+++ b/lib/uplink/packages/install.ex
@@ -2,6 +2,8 @@ defmodule Uplink.Packages.Install do
   use Ecto.Schema
   import Ecto.Changeset
 
+  import Ecto.Query, only: [from: 2]
+
   alias Uplink.Packages.Deployment
 
   use Eventful.Transitable,
@@ -20,5 +22,28 @@ defmodule Uplink.Packages.Install do
     install
     |> cast(params, [:instellar_installation_id])
     |> validate_required([:instellar_installation_id])
+  end
+
+  def latest_by_installation_id(count \\ 1) do
+    ranking_query =
+      from(
+        i in __MODULE__,
+        select: %{
+          id: i.id,
+          row_number: over(row_number(), :installations_partition)
+        },
+        windows: [
+          installations_partition: [
+            partition_by: :instellar_installation_id,
+            order_by: [desc: :inserted_at]
+          ]
+        ]
+      )
+
+    from(
+      i in __MODULE__,
+      join: r in subquery(ranking_query),
+      on: i.id == r.id and r.row_number <= ^count
+    )
   end
 end

--- a/lib/uplink/packages/metadata.ex
+++ b/lib/uplink/packages/metadata.ex
@@ -8,7 +8,7 @@ defmodule Uplink.Packages.Metadata do
     field :slug, :string
     field :service_port, :integer
     field :exposed_port, :integer
-    field :hosts, {:array, :string}
+    field :hosts, {:array, :string}, default: []
 
     embeds_one :channel, Channel, primary_key: false do
       field :slug, :string

--- a/lib/uplink/packages/metadata.ex
+++ b/lib/uplink/packages/metadata.ex
@@ -8,6 +8,7 @@ defmodule Uplink.Packages.Metadata do
     field :slug, :string
     field :service_port, :integer
     field :exposed_port, :integer
+    field :hosts, {:array, :string}
 
     embeds_one :channel, Channel, primary_key: false do
       field :slug, :string
@@ -42,7 +43,7 @@ defmodule Uplink.Packages.Metadata do
 
   def changeset(%__MODULE__{} = metadata, params) do
     metadata
-    |> cast(params, [:id, :slug, :service_port, :exposed_port])
+    |> cast(params, [:id, :slug, :service_port, :exposed_port, :hosts])
     |> validate_required([:id, :slug])
     |> cast_embed(:channel, required: true, with: &channel_changeset/2)
     |> cast_embed(:instances, required: true, with: &instance_changeset/2)

--- a/test/fixtures/caddy/config/get.json
+++ b/test/fixtures/caddy/config/get.json
@@ -1,0 +1,24 @@
+{
+  "apps": {
+    "http": {
+      "servers": {
+        "example": {
+          "listen": [
+            ":2015"
+          ],
+          "routes": [
+            {
+              "handle": [
+                {
+                  "@id": "test",
+                  "body": "Hello, world!",
+                  "handler": "static_response"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/scenarios/deployment.ex
+++ b/test/scenarios/deployment.ex
@@ -20,6 +20,7 @@ defmodule Uplink.Scenarios.Deployment do
       "slug" => "uplink-web",
       "service_port" => 4000,
       "exposed_port" => 49152,
+      "hosts" => ["something.com"],
       "variables" => [
         %{"key" => "SOMETHING", "value" => "blah"}
       ],

--- a/test/uplink/clients/caddy/config/builder_test.exs
+++ b/test/uplink/clients/caddy/config/builder_test.exs
@@ -1,0 +1,22 @@
+defmodule Uplink.Clients.Caddy.Config.BuilderTest do
+  use ExUnit.Case
+
+  import Uplink.Scenarios.Deployment
+
+  setup [:setup_endpoints, :setup_base]
+
+  test "generate caddy config" do
+    assert %{admin: admin, apps: apps} =
+             Uplink.Clients.Caddy.Config.Builder.new()
+
+    assert %{http: %{servers: %{"uplink" => server}}} = apps
+    assert %{routes: [route]} = server
+    assert %{handle: [handle], match: [match]} = route
+    assert %{handler: "reverse_proxy"} = handle
+    assert %{host: _hosts} = match
+
+    assert %{identity: identity} = admin
+    assert %{issuers: [zerossl]} = identity
+    assert %{module: "zerossl"} = zerossl
+  end
+end

--- a/test/uplink/clients/caddy_test.exs
+++ b/test/uplink/clients/caddy_test.exs
@@ -1,0 +1,48 @@
+defmodule Uplink.Clients.CaddyTest do
+  use ExUnit.Case
+
+  alias Uplink.Clients.Caddy
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :uplink,
+      Uplink.Clients.Caddy,
+      endpoint: "http://localhost:#{bypass.port}"
+    )
+
+    config_params = File.read!("test/fixtures/caddy/config/get.json")
+
+    {:ok, bypass: bypass, config_params: config_params}
+  end
+
+  describe "get config" do
+    test "get and parse config", %{bypass: bypass, config_params: config_params} do
+      Bypass.expect(bypass, "GET", "/config/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, config_params)
+      end)
+
+      assert {:ok, config} = Caddy.get_config()
+
+      assert %{apps: %Caddy.Apps{}} = config
+    end
+  end
+
+  describe "load config" do
+    test "successfully load config into caddy", %{
+      bypass: bypass,
+      config_params: config_params
+    } do
+      Bypass.expect(bypass, "POST", "/load", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, "")
+      end)
+
+      assert {:ok, ""} = Caddy.load_config(config_params)
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces caddy integration into uplink. Caddy will serve as the load balancer for handling the mesh routing to all services.

## Goal

The goal of this PR is to enable user to input the domain they want for any given service running on the instellar cluster.

- [x] Caddy client
- [x] Caddy data structures mapping

Signed-off-by: Zack Siri <me@zacksiri.dev>