### PR TITLE
Feature/remove instellar orchestration dependency

### DIFF
--- a/lib/uplink/clients/caddy.ex
+++ b/lib/uplink/clients/caddy.ex
@@ -29,7 +29,7 @@ defmodule Uplink.Clients.Caddy do
       end
 
     params
-    |> Config.Reload.new(schedule_in: 5)
+    |> Config.Reload.new(schedule_in: 1)
     |> Oban.insert()
   end
 

--- a/lib/uplink/clients/caddy/config/reload.ex
+++ b/lib/uplink/clients/caddy/config/reload.ex
@@ -43,26 +43,6 @@ defmodule Uplink.Clients.Caddy.Config.Reload do
       end)
     end)
 
-    maybe_mark_install_complete(install, params)
-
     :ok
   end
-
-  defp maybe_mark_install_complete(
-         %Install{current_state: "refreshing"} = install,
-         params
-       ) do
-    actor_id = Map.get(params, "actor_id")
-
-    actor =
-      if actor_id do
-        Repo.get(Members.Actor, actor_id)
-      else
-        Members.get_bot!()
-      end
-
-    Packages.transition_install_with(install, actor, "complete")
-  end
-
-  defp maybe_mark_install_complete(_install, _params), do: :ok
 end

--- a/lib/uplink/clients/instellar/instance.ex
+++ b/lib/uplink/clients/instellar/instance.ex
@@ -21,7 +21,8 @@ defmodule Uplink.Clients.Instellar.Instance do
       json: %{
         "event" => %{
           "name" => event_name,
-          "comment" => Keyword.get(options, :comment)
+          "comment" => Keyword.get(options, :comment),
+          "parameters" => Keyword.get(options, :parameters, %{})
         }
       },
       headers: Instellar.headers(install.deployment.hash)

--- a/lib/uplink/clients/lxd.ex
+++ b/lib/uplink/clients/lxd.ex
@@ -20,7 +20,7 @@ defmodule Uplink.Clients.LXD do
     to: __MODULE__.Instance.Manager,
     as: :list
 
-  defdelegate list_instances(), 
+  defdelegate list_instances(),
     to: __MODULE__.Instance.Manager,
     as: :list
 

--- a/lib/uplink/clients/lxd.ex
+++ b/lib/uplink/clients/lxd.ex
@@ -20,6 +20,10 @@ defmodule Uplink.Clients.LXD do
     to: __MODULE__.Instance.Manager,
     as: :list
 
+  defdelegate list_instances(), 
+    to: __MODULE__.Instance.Manager,
+    as: :list
+
   defdelegate managed_network(),
     to: __MODULE__.Network.Manager,
     as: :managed

--- a/lib/uplink/clients/lxd/instance/manager.ex
+++ b/lib/uplink/clients/lxd/instance/manager.ex
@@ -6,7 +6,6 @@ defmodule Uplink.Clients.LXD.Instance.Manager do
   alias Clients.LXD
   alias LXD.Instance
 
-
   def list do
     LXD.client()
     |> Lexdee.list_instances(query: [{:recursion, 1}, {"all-projects", true}])

--- a/lib/uplink/clients/lxd/instance/manager.ex
+++ b/lib/uplink/clients/lxd/instance/manager.ex
@@ -6,6 +6,25 @@ defmodule Uplink.Clients.LXD.Instance.Manager do
   alias Clients.LXD
   alias LXD.Instance
 
+
+  def list do
+    LXD.client()
+    |> Lexdee.list_instances(query: [{:recursion, 1}, {"all-projects", true}])
+    |> case do
+      {:ok, %{body: instances}} ->
+        instances =
+          instances
+          |> Enum.map(fn instance ->
+            Instance.parse(instance)
+          end)
+
+        instances
+
+      error ->
+        error
+    end
+  end
+
   def list(project) do
     LXD.client()
     |> Lexdee.list_instances(query: [recursion: 1, project: project])

--- a/lib/uplink/packages.ex
+++ b/lib/uplink/packages.ex
@@ -37,6 +37,10 @@ defmodule Uplink.Packages do
     to: Install.Manager,
     as: :transition_with
 
+  defdelegate maybe_mark_install_complete(install, actor),
+    to: Install.Manager,
+    as: :maybe_mark_complete
+
   alias __MODULE__.Deployment
 
   defdelegate get_deployment(id),

--- a/lib/uplink/packages/install/manager.ex
+++ b/lib/uplink/packages/install/manager.ex
@@ -52,6 +52,17 @@ defmodule Uplink.Packages.Install.Manager do
     |> Repo.one()
   end
 
+  def maybe_mark_complete(%Install{} = install, actor) do
+    completed_instances = Cache.get({:install, install.id, "completed"})
+    executing_instances = Cache.get({:install, install.id, "executing"})
+
+    if Enum.count(completed_instances) == Enum.count(executing_instances) do
+      Packages.transition_install_with(install, actor, "complete")
+    else
+      {:ok, :still_executing}
+    end
+  end
+
   @spec build_state(%Install{}, %Actor{} | nil) :: %{
           install: %Install{},
           metadata: %Metadata{},

--- a/lib/uplink/packages/install/manager.ex
+++ b/lib/uplink/packages/install/manager.ex
@@ -59,7 +59,7 @@ defmodule Uplink.Packages.Install.Manager do
     if Enum.count(completed_instances) == Enum.count(executing_instances) do
       Packages.transition_install_with(install, actor, "complete")
     else
-      {:ok, :still_executing}
+      {:ok, :executing}
     end
   end
 

--- a/lib/uplink/packages/instance/bootstrap.ex
+++ b/lib/uplink/packages/instance/bootstrap.ex
@@ -65,6 +65,8 @@ defmodule Uplink.Packages.Instance.Bootstrap do
       LXD.list_cluster_members()
       |> Enum.min_by(fn m -> frequency[m.server_name] || 0 end)
 
+    transition_parameters = Map.put(@transition_parameters, "node", selected_member.server_name)
+
     with %{metadata: %{channel: channel} = metadata} <-
            Packages.build_install_state(install, actor),
          members when is_list(members) <- LXD.list_cluster_members(),
@@ -77,7 +79,7 @@ defmodule Uplink.Packages.Instance.Bootstrap do
            @task_supervisor.async_nolink(Uplink.TaskSupervisor, fn ->
              Instellar.transition_instance(name, install, "boot",
                comment: "[Uplink.Packages.Instance.Bootstrap]",
-               parameters: @transition_parameters
+               parameters: transition_parameters
              )
            end) do
       profile_name = Packages.profile_name(metadata)

--- a/lib/uplink/packages/instance/finalize.ex
+++ b/lib/uplink/packages/instance/finalize.ex
@@ -15,7 +15,10 @@ defmodule Uplink.Packages.Instance.Finalize do
   def perform(%Oban.Job{
         args:
           %{
-            "instance" => %{"slug" => name} = instance_params,
+            "instance" =>
+              %{
+                "slug" => name
+              } = instance_params,
             "comment" => comment,
             "install_id" => install_id,
             "actor_id" => actor_id

--- a/lib/uplink/packages/instance/finalize.ex
+++ b/lib/uplink/packages/instance/finalize.ex
@@ -1,0 +1,40 @@
+defmodule Uplink.Packages.Instance.Finalize do
+  use Oban.Worker, queue: :instance, max_attempts: 5
+
+  alias Uplink.Repo
+  alias Uplink.Clients.Instellar
+  alias Uplink.Packages.Install
+
+  import Ecto.Query, only: [preload: 2]
+
+  @transition_parameters %{
+    "from" => "uplink",
+    "trigger" => false
+  }
+
+  def perform(%Oban.Job{
+        args:
+          %{
+            "instance" => %{"slug" => name} = instance_params,
+            "comment" => comment,
+            "install_id" => install_id,
+            "actor_id" => actor_id
+          } = args
+      }) do
+    %Install{} =
+      install =
+      Install
+      |> preload([:deployment])
+      |> Repo.get(install_id)
+
+    node = Map.get(instance_params, "node", %{})
+
+    transition_parameters =
+      Map.put(@transition_parameters, "node", node["slug"])
+
+    Instellar.transition_instance(name, install, "complete",
+      comment: comment,
+      parameters: transition_parameters
+    )
+  end
+end

--- a/lib/uplink/packages/instance/upgrade.ex
+++ b/lib/uplink/packages/instance/upgrade.ex
@@ -151,8 +151,6 @@ defmodule Uplink.Packages.Instance.Upgrade do
         |> Instance.Finalize.new()
         |> Oban.insert()
 
-        {:ok, upgrade_package_output}
-
       {:error, %{"err" => "Failed to retrieve PID of executing child process"}} ->
         Uplink.TaskSupervisor
         |> @task_supervisor.async_nolink(

--- a/lib/uplink/packages/instance/upgrade.ex
+++ b/lib/uplink/packages/instance/upgrade.ex
@@ -3,33 +3,36 @@ defmodule Uplink.Packages.Instance.Upgrade do
     queue: :instance,
     max_attempts: 1
 
-  alias Uplink.{
-    Members,
-    Clients,
-    Packages,
-    Repo
-  }
+  alias Uplink.Repo
+  alias Uplink.Cache
 
-  alias Members.Actor
+  alias Uplink.Packages
+  alias Uplink.Packages.Install
+  alias Uplink.Packages.Instance
 
-  alias Packages.{
-    Install,
-    Instance
-  }
+  alias Uplink.Members.Actor
 
-  alias Clients.{
-    LXD,
-    Instellar
-  }
+  alias Uplink.Clients.LXD
+  alias Uplink.Clients.Instellar
+  alias Uplink.Clients.Caddy
 
   import Ecto.Query, only: [limit: 2, where: 3, preload: 2, order_by: 2]
+
+  @transition_parameters %{
+    "from" => "uplink",
+    "trigger" => false
+  }
+
+  @task_supervisor Application.compile_env(:uplink, :task_supervisor) ||
+                     Task.Supervisor
 
   def perform(
         %Oban.Job{
           args: %{
-            "instance" => %{
-              "slug" => name
-            },
+            "instance" =>
+              %{
+                "slug" => name
+              } = instance_params,
             "install_id" => install_id,
             "actor_id" => actor_id
           }
@@ -43,29 +46,37 @@ defmodule Uplink.Packages.Instance.Upgrade do
       |> preload([:deployment])
       |> Repo.get(install_id)
 
-    with %{metadata: %{channel: channel} = metadata} <-
-           Packages.build_install_state(install, actor),
-         {:ok, _transition} <-
-           Instellar.transition_instance(name, install, "upgrade",
-             comment: "[Uplink.Packages.Instance.Upgrade]"
-           ) do
-      client = LXD.client()
+    node = Map.get(instance_params, "node", %{})
 
-      project_name = Packages.get_project_name(client, metadata)
+    transition_parameters =
+      Map.put(@transition_parameters, "node", node["slug"])
 
-      Formation.new_lxd_instance(%{
-        project: project_name,
-        slug: name,
-        repositories: [],
-        packages: [
-          %{
-            slug: channel.package.slug
-          }
-        ]
-      })
-      |> validate_stack(install)
-      |> handle_upgrade(job, actor)
-    end
+    %{metadata: %{channel: channel} = metadata} =
+      Packages.build_install_state(install, actor)
+
+    client = LXD.client()
+    project_name = Packages.get_project_name(client, metadata)
+
+    @task_supervisor.async_nolink(Uplink.TaskSupervisor, fn ->
+      Instellar.transition_instance(name, install, "upgrade",
+        comment:
+          "[Uplink.Packages.Instance.Upgrade] Upgrading #{channel.package.slug} on #{name}...",
+        parameters: transition_parameters
+      )
+    end)
+
+    Formation.new_lxd_instance(%{
+      project: project_name,
+      slug: name,
+      repositories: [],
+      packages: [
+        %{
+          slug: channel.package.slug
+        }
+      ]
+    })
+    |> validate_stack(install)
+    |> handle_upgrade(job, actor)
   end
 
   defp validate_stack(
@@ -101,30 +112,64 @@ defmodule Uplink.Packages.Instance.Upgrade do
 
   defp handle_upgrade(
          {:upgrade, formation_instance, install},
-         %Job{} = job,
+         %Job{args: %{"instance" => instance_params}} = job,
          actor
        ) do
+    node = Map.get(instance_params, "node", %{})
+
+    transition_parameters =
+      Map.put(@transition_parameters, "node", node["slug"])
+
     LXD.client()
     |> Formation.lxd_upgrade_alpine_package(formation_instance)
     |> case do
       {:ok, upgrade_package_output} ->
-        Instellar.transition_instance(
-          formation_instance.slug,
-          install,
-          "complete",
-          comment: upgrade_package_output
-        )
+        Cache.transaction([keys: [{:install, install.id, "completed"}]], fn ->
+          Cache.get_and_update(
+            {:install, install.id, "completed"},
+            fn current_value ->
+              completed_instances =
+                if current_value,
+                  do: current_value ++ [formation_instance.slug],
+                  else: [formation_instance.slug]
 
-        maybe_mark_install_complete(install, actor)
+              {current_value, Enum.uniq(completed_instances)}
+            end
+          )
+        end)
+
+        Caddy.schedule_config_reload(install)
+
+        Packages.maybe_mark_install_complete(install, actor)
+
+        %{
+          "instance" => instance_params,
+          "comment" => upgrade_package_output,
+          "install_id" => install.id,
+          "actor_id" => actor.id
+        }
+        |> Instance.Finalize.new()
+        |> Oban.insert()
+
+        {:ok, upgrade_package_output}
 
       {:error, %{"err" => "Failed to retrieve PID of executing child process"}} ->
-        Instellar.transition_instance(
-          formation_instance.slug,
-          install,
-          "revert",
-          comment:
-            "Reverting please restart the underlying node and try upgrading again."
+        Uplink.TaskSupervisor
+        |> @task_supervisor.async_nolink(
+          fn ->
+            Instellar.transition_instance(
+              formation_instance.slug,
+              install,
+              "revert",
+              comment:
+                "Reverting please restart the underlying node and try upgrading again.",
+              parameters: transition_parameters
+            )
+          end,
+          shutdown: 30_000
         )
+
+        {:ok, :reverted}
 
       {:error, error} ->
         handle_error(error, job)
@@ -152,16 +197,5 @@ defmodule Uplink.Packages.Instance.Upgrade do
     })
     |> Instance.Cleanup.new()
     |> Oban.insert()
-  end
-
-  defp maybe_mark_install_complete(install, actor) do
-    with {:ok, %{"current_state" => "synced"}} <-
-           Instellar.deployment_metadata(install),
-         {:ok, transition} <-
-           Packages.transition_install_with(install, actor, "complete") do
-      {:ok, transition}
-    else
-      _ -> :ok
-    end
   end
 end

--- a/livebook/lxd.livemd
+++ b/livebook/lxd.livemd
@@ -1,0 +1,32 @@
+# LXD Compute least used member
+
+## Update cache
+
+We need to update the cache with the key `:self` because that's where the credential for uplink's lxd is stored.
+
+```elixir
+cert = File.read!(Path.expand("~/.config/lxc/client.crt"))
+key = File.read!(Path.expand("~/.config/lxc/client.key"))
+
+credential = %{
+  "endpoint" => "https://198.19.249.83:8443",
+  "certificate" => cert,
+  "private_key" => key
+}
+
+Uplink.Cache.put(:self, %{"credential" => credential})
+```
+
+## Query instances
+
+```elixir
+alias Uplink.Clients.LXD
+
+frequency =
+  LXD.list_instances()
+  |> Enum.frequencies_by(fn i -> i.location end)
+  |> IO.inspect()
+
+LXD.list_cluster_members()
+|> Enum.min_by(fn m -> frequency[m.server_name] || 0 end)
+```

--- a/test/scenarios/mocks.ex
+++ b/test/scenarios/mocks.ex
@@ -1,6 +1,6 @@
 Mox.defmock(Uplink.Drivers.Bucket.AwsMock, for: Uplink.Drivers.Behaviour)
 
 defmodule Uplink.TaskSupervisorMock do
-  def async_nolink(_supervisor, fun),
+  def async_nolink(_supervisor, fun, _options \\ []),
     do: fun.()
 end

--- a/test/uplink/clients/caddy/config/reload_test.exs
+++ b/test/uplink/clients/caddy/config/reload_test.exs
@@ -3,7 +3,6 @@ defmodule Uplink.Clients.Caddy.Config.ReloadTest do
   use Oban.Testing, repo: Uplink.Repo
 
   alias Uplink.{
-    Repo,
     Cache,
     Members,
     Packages
@@ -191,38 +190,6 @@ defmodule Uplink.Clients.Caddy.Config.ReloadTest do
 
       assert :ok ==
                perform_job(Config.Reload, %{install_id: install.id})
-    end
-
-    test "mark install completed when refreshing", %{
-      bypass: bypass,
-      install: install
-    } do
-      {:ok, install} =
-        install
-        |> Ecto.Changeset.cast(%{current_state: "refreshing"}, [:current_state])
-        |> Repo.update()
-
-      Bypass.expect(bypass, "POST", "/load", fn conn ->
-        conn
-        |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.resp(200, "")
-      end)
-
-      Bypass.expect_once(bypass, "GET", "/uplink/installations/1", fn conn ->
-        conn
-        |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.resp(
-          200,
-          Jason.encode!(@uplink_installation_state_response)
-        )
-      end)
-
-      assert :ok ==
-               perform_job(Config.Reload, %{install_id: install.id})
-
-      install = Repo.reload(install)
-
-      assert install.current_state == "completed"
     end
   end
 end

--- a/test/uplink/clients/lxd/cluster/manager_test.exs
+++ b/test/uplink/clients/lxd/cluster/manager_test.exs
@@ -38,7 +38,7 @@ defmodule Uplink.Clients.LXD.Cluster.ManagerTest do
       end)
 
       assert [member1] = Manager.list_members()
-      assert %Cluster.Member{} = IO.inspect(member1)
+      assert %Cluster.Member{} = member1
     end
   end
 end

--- a/test/uplink/clients/lxd/cluster/manager_test.exs
+++ b/test/uplink/clients/lxd/cluster/manager_test.exs
@@ -38,7 +38,7 @@ defmodule Uplink.Clients.LXD.Cluster.ManagerTest do
       end)
 
       assert [member1] = Manager.list_members()
-      assert %Cluster.Member{} = member1
+      assert %Cluster.Member{} = IO.inspect(member1)
     end
   end
 end

--- a/test/uplink/packages/instance/bootstrap_test.exs
+++ b/test/uplink/packages/instance/bootstrap_test.exs
@@ -38,6 +38,14 @@ defmodule Uplink.Packages.Instance.BootstrapTest do
       |> Plug.Conn.resp(200, cluster_members)
     end)
 
+    instances_list = File.read!("test/fixtures/lxd/instances/list/empty.json")
+
+    Bypass.expect_once(bypass, "GET", "/1.0/instances", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/json")
+      |> Plug.Conn.resp(200, instances_list)
+    end)
+
     Cache.delete(:cluster_members)
 
     create_instance = File.read!("test/fixtures/lxd/instances/create.json")

--- a/test/uplink/packages/instance/bootstrap_test.exs
+++ b/test/uplink/packages/instance/bootstrap_test.exs
@@ -70,20 +70,6 @@ defmodule Uplink.Packages.Instance.BootstrapTest do
   end
 
   describe "bootstrap instance" do
-    test "no matching cluster member", %{
-      install: install,
-      actor: actor
-    } do
-      assert {:ok, %{resource: install}} =
-               perform_job(Bootstrap, %{
-                 instance: %{slug: "something-1", node: %{slug: "some-node-01"}},
-                 install_id: install.id,
-                 actor_id: actor.id
-               })
-
-      assert install.current_state == "failed"
-    end
-
     test "when project does not exist", %{
       bypass: bypass,
       install: install,

--- a/test/uplink/packages/instance/finalize_test.exs
+++ b/test/uplink/packages/instance/finalize_test.exs
@@ -1,0 +1,134 @@
+defmodule Uplink.Packages.Instance.FinalizeTest do
+  use ExUnit.Case
+  use Oban.Testing, repo: Uplink.Repo
+
+  alias Uplink.Cache
+  alias Uplink.Members
+
+  alias Uplink.Packages
+  alias Uplink.Packages.Metadata
+
+  @deployment_params %{
+    "hash" => "some-hash",
+    "archive_url" => "http://localhost/archives/packages.zip",
+    "stack" => "alpine/3.14",
+    "channel" => "develop",
+    "metadata" => %{
+      "id" => 1,
+      "slug" => "uplink-web",
+      "main_port" => %{
+        "slug" => "web",
+        "source" => 49153,
+        "target" => 4000
+      },
+      "channel" => %{
+        "slug" => "develop",
+        "package" => %{
+          "slug" => "something-1640927800",
+          "credential" => %{
+            "public_key" => "public_key"
+          },
+          "organization" => %{
+            "slug" => "upmaru"
+          }
+        }
+      },
+      "instances" => [
+        %{
+          "id" => 1,
+          "slug" => "something-1",
+          "node" => %{
+            "slug" => "some-node"
+          }
+        }
+      ]
+    }
+  }
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Uplink.Repo)
+
+    bypass = Bypass.open()
+
+    Cache.put(:self, %{
+      "credential" => %{
+        "endpoint" => "http://localhost:#{bypass.port}"
+      }
+    })
+
+    Application.put_env(
+      :uplink,
+      Uplink.Clients.Instellar,
+      endpoint: "http://localhost:#{bypass.port}/uplink"
+    )
+
+    {:ok, actor} =
+      Members.get_or_create_actor(%{
+        "identifier" => "zacksiri",
+        "provider" => "instellar",
+        "id" => "1"
+      })
+
+    metadata = Map.get(@deployment_params, "metadata")
+
+    {:ok, metadata} = Packages.parse_metadata(metadata)
+
+    app =
+      metadata
+      |> Metadata.app_slug()
+      |> Packages.get_or_create_app()
+
+    {:ok, deployment} =
+      Packages.get_or_create_deployment(app, @deployment_params)
+
+    {:ok, install} = Packages.create_install(deployment, 1)
+
+    {:ok, bypass: bypass, install: install, actor: actor}
+  end
+
+  describe "perform" do
+    alias Uplink.Packages.Instance.Finalize
+
+    test "calls instellar to mark instance complete", %{
+      bypass: bypass,
+      install: install,
+      actor: actor
+    } do
+      instance_slug = "some-instance-01"
+
+      Bypass.expect(
+        bypass,
+        "POST",
+        "/uplink/installations/#{install.instellar_installation_id}/instances/#{instance_slug}/events",
+        fn conn ->
+          assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+          assert {:ok, body} = Jason.decode(body)
+
+          %{"event" => %{"name" => event_name}} = body
+
+          assert event_name in ["complete"]
+
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.resp(
+            201,
+            Jason.encode!(%{
+              "data" => %{"attributes" => %{"id" => 1, "name" => event_name}}
+            })
+          )
+        end
+      )
+
+      assert {:ok, %{"id" => 1, "name" => "complete"}} =
+               perform_job(
+                 Finalize,
+                 %{
+                   "instance" => %{"slug" => instance_slug},
+                   "comment" => "all good!",
+                   "install_id" => install.id,
+                   "actor_id" => actor.id
+                 }
+               )
+    end
+  end
+end

--- a/test/uplink/packages/instance/install_test.exs
+++ b/test/uplink/packages/instance/install_test.exs
@@ -274,7 +274,7 @@ defmodule Uplink.Packages.Instance.InstallTest do
 
           %{"event" => %{"name" => event_name}} = body
 
-          assert event_name in ["complete", "boot"]
+          assert event_name in ["boot"]
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")

--- a/test/uplink/packages/instance/upgrade_test.exs
+++ b/test/uplink/packages/instance/upgrade_test.exs
@@ -517,7 +517,7 @@ defmodule Uplink.Packages.Instance.UpgradeTest do
         end
       )
 
-      assert {:ok, %{"id" => _, "name" => "revert"}} =
+      assert {:ok, :reverted} =
                perform_job(Upgrade, %{
                  instance: %{
                    slug: instance_slug,

--- a/test/uplink/packages/instance/upgrade_test.exs
+++ b/test/uplink/packages/instance/upgrade_test.exs
@@ -4,10 +4,9 @@ defmodule Uplink.Packages.Instance.UpgradeTest do
 
   import Uplink.Scenarios.Deployment
 
-  alias Uplink.{
-    Packages,
-    Repo
-  }
+  alias Uplink.Repo
+  alias Uplink.Cache
+  alias Uplink.Packages
 
   setup [:setup_endpoints, :setup_base]
 
@@ -85,44 +84,12 @@ defmodule Uplink.Packages.Instance.UpgradeTest do
     }
   }
 
-  @uplink_installation_state_response %{
-    "data" => %{
-      "attributes" => %{
-        "id" => 1,
-        "slug" => "uplink-web",
-        "main_port" => %{
-          "slug" => "web",
-          "source" => 49142,
-          "target" => 4000
-        },
-        "current_state" => "synced",
-        "variables" => [
-          %{"key" => "SOMETHING", "value" => "somevalue"}
-        ],
-        "channel" => %{
-          "slug" => "develop",
-          "package" => %{
-            "slug" => "something-1640927800",
-            "credential" => %{
-              "public_key" => "public_key"
-            },
-            "organization" => %{
-              "slug" => "upmaru"
-            }
-          }
-        },
-        "instances" => [
-          %{
-            "id" => 1,
-            "slug" => "something-1",
-            "node" => %{
-              "slug" => "some-node"
-            }
-          }
-        ]
-      }
-    }
-  }
+  setup %{install: install} do
+    Cache.put({:install, install.id, "completed"}, [])
+    Cache.put({:install, install.id, "executing"}, ["some-instance-01"])
+
+    :ok
+  end
 
   describe "upgrade instance" do
     alias Uplink.Packages.Instance.Upgrade
@@ -224,6 +191,8 @@ defmodule Uplink.Packages.Instance.UpgradeTest do
         end
       )
 
+      complete_message = "upgrade complete"
+
       Bypass.expect_once(
         bypass,
         "GET",
@@ -236,7 +205,7 @@ defmodule Uplink.Packages.Instance.UpgradeTest do
           conn
           |> Plug.Conn.resp(
             200,
-            "upgrade complete"
+            complete_message
           )
         end
       )
@@ -277,16 +246,7 @@ defmodule Uplink.Packages.Instance.UpgradeTest do
         end
       )
 
-      Bypass.expect(bypass, "GET", "/uplink/installations/1", fn conn ->
-        conn
-        |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.resp(
-          200,
-          Jason.encode!(@uplink_installation_state_response)
-        )
-      end)
-
-      assert {:ok, %{event: event}} =
+      assert {:ok, %Oban.Job{worker: worker}} =
                perform_job(Upgrade, %{
                  instance: %{
                    slug: instance_slug,
@@ -296,7 +256,7 @@ defmodule Uplink.Packages.Instance.UpgradeTest do
                  actor_id: actor.id
                })
 
-      assert event.name == "complete"
+      assert worker == "Uplink.Packages.Instance.Finalize"
     end
 
     test "on error it enqueue deactivate and bootstrap", %{


### PR DESCRIPTION
- [x] Clean up all instance lifecycle workers
- [x] Reduce dependency on instellar
- [x] Uplink orchestrates it's own install / upgrade lifecycle
- [x] Track `executing` instances for a given `Package.Install`
- [x] Caddy only routes traffic to `completed` instances
- [x] Clean up tests
- [x] Add test for `Instance.Finalize` worker